### PR TITLE
use modern futures & tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,17 +6,17 @@ edition = "2018"
 
 [dependencies]
 backoff           = "0.1.3"
-bytes             = "0.4.12"
+bytes             = "1.1.0"
 crossbeam-channel = "0.3.8"
-futures           = "0.1.26"
-futures-retry     = "0.3.0"
+futures           = "0.3.21"
+futures-retry     = "0.6.0"
 log               = "0.4.6"
 rmp-serde         = "0.13.7"
 serde_bytes       = "0.11.1"
 
 [dependencies.reqwest]
-version  = "0.9.15"
-features = ["rustls-tls"]
+version  = "0.11.10"
+features = ["blocking", "json", "rustls-tls"]
 default-features = false
 
 [dependencies.serde]
@@ -24,8 +24,8 @@ version  = "1.0.90"
 features = ["derive"]
 
 [dependencies.tokio]
-version  = "0.1.18"
-features = ["rt-full", "tcp"]
+version  = "1.17.0"
+features = ["rt-multi-thread"]
 default-features = false
 
 [dev-dependencies]
@@ -34,6 +34,7 @@ actix-service = "=0.3.4"
 base64        = "0.10.1"
 criterion     = "0.2.10"
 env_logger    = "0.6.1"
+http          = "0.2.6"
 rand          = "0.6.5"
 serde_json    = "1.0.39"
 
@@ -47,6 +48,14 @@ default-features = false
 
 [dev-dependencies.actix-web-codegen]
 version  = "=0.1.0-alpha.1"
+
+[dev-dependencies.bytes_old]
+package  = "bytes"
+version  = "0.4.12"
+
+[dev-dependencies.futures_old]
+package  = "futures"
+version  = "0.1.26"
 
 [[bench]]
 name    = "benches"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use env_logger;
 use kentik_api::client::*;
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
     let email    = env::var("EMAIL").expect("env var EMAIL");

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -4,7 +4,7 @@ use env_logger;
 use kentik_api::client::*;
 use kentik_api::core::Dimension;
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
     let email    = env::var("EMAIL").expect("env var EMAIL");

--- a/examples/tags.rs
+++ b/examples/tags.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use env_logger;
 use kentik_api::tag::*;
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
     let email    = env::var("EMAIL").expect("env var EMAIL");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@ impl Error {
     fn into_backoff(self) -> backoff::Error<Self> {
         match self {
             Error::Auth | Error::Empty => backoff::Error::Permanent(self),
-            Error::App(_, 300...499)   => backoff::Error::Permanent(self),
-            Error::Status(300...499)   => backoff::Error::Permanent(self),
+            Error::App(_, 300..=499)   => backoff::Error::Permanent(self),
+            Error::Status(300..=499)   => backoff::Error::Permanent(self),
             _                          => backoff::Error::Transient(self),
         }
     }

--- a/tests/server/mod.rs
+++ b/tests/server/mod.rs
@@ -11,10 +11,10 @@ use actix_web::{*, dev, web::*};
 use actix_web::http::{Method, HeaderValue};
 use actix_web::dev::{Payload, ServiceRequest, ServiceResponse};
 use actix_web::error::PayloadError;
-use bytes::Bytes;
+use bytes_old::Bytes;
 use crossbeam_channel::*;
-use futures::{Async, Future, Poll, Stream};
-use futures::future::{ok, FutureResult};
+use futures_old::{Async, Future, Poll, Stream};
+use futures_old::future::{ok, FutureResult};
 use rand::prelude::*;
 use serde::{Serialize, Deserialize};
 use kentik_api::core::{Device, Dimension};
@@ -149,7 +149,7 @@ impl<S, P, B> Service for AuthMiddleware<S> where
     type Request  = ServiceRequest<P>;
     type Response = ServiceResponse<B>;
     type Error    = Error;
-    type Future   = Box<Future<Item = Self::Response, Error = Self::Error>>;
+    type Future   = Box<dyn Future<Item = Self::Response, Error = Self::Error>>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         self.service.poll_ready()


### PR DESCRIPTION
Update code and dependencies to use the latest futures & tokio crates which have seen significant improvements in the past few years. This also fixes an issue with runtime crashes due to improvements to the Rust compiler that trigger bad behavior in the tokio 0.1 crates.